### PR TITLE
Add issue templates

### DIFF
--- a/ISSUE_TEMPLATE/bug.yml
+++ b/ISSUE_TEMPLATE/bug.yml
@@ -13,6 +13,16 @@ body:
       validations:
         required: true
 
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: >-
+        If the issue is ocurring in a particular environment, please provide its
+        name or URL
+      validations:
+        required: false
+
   - type: textarea
     id: reproduction
     attributes:

--- a/ISSUE_TEMPLATE/bug.yml
+++ b/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,54 @@
+---
+name: Bug Report
+description: Report a bug
+labels:
+  - bug
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >-
+        Please provide a general description of the bug you're experiencing
+      validations:
+        required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: >-
+        A series of steps that can be taken to reproduce the bug.
+
+        If there is a particular code sample that can be provided, please provide either a
+        link or a relevant snippet of the code.
+      validations:
+        required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: >-
+        What did you expect to happen when you encountered the bug?
+      validations:
+        required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: >-
+        What unexpected behavior actually occurred? Please include specific error messages,
+        if relevant.
+      validations:
+        required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Notes
+      description: >-
+        Any additional information that you feel may be relevant to this bug report
+      validations:
+        required: false

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+---
+blank_issues_enabled: true

--- a/ISSUE_TEMPLATE/feature.yml
+++ b/ISSUE_TEMPLATE/feature.yml
@@ -13,9 +13,18 @@ body:
         may be helpful to frame this as a
         [user story](https://www.atlassian.com/agile/project-management/user-stories), such as:
 
-        > As a user, I want to [feature], to that [use case].
+        > As a user, I want to [feature], so that [use case].
       validations:
         required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: >-
+        The conditions that must be met for this ticket to be accepted
+      validations:
+        required: false
 
   - type: textarea
     id: solution

--- a/ISSUE_TEMPLATE/feature.yml
+++ b/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,44 @@
+---
+name: Feature Request
+description: Request an enhancement or new feature
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >-
+        An overview of the feature that you would like to see added, including a use case. It
+        may be helpful to frame this as a
+        [user story](https://www.atlassian.com/agile/project-management/user-stories), such as:
+
+        > As a user, I want to [feature], to that [use case].
+      validations:
+        required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: >-
+        If you have an idea for how this feature could be implemented, please provide that
+      validations:
+        required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Notes
+      description: >-
+        foo
+      validations:
+        required: false
+
+  - type: checkboxes
+    id: implementation
+    attributes:
+      label: Implementation
+      options:
+        - label: I can (or plan to) submit a pull request to implement this
+        - label: Implementing this may result in a breaking change


### PR DESCRIPTION
Initially when starting to create the `.github` repository, it was
determined we'd hold off on creating issue templates and such until we
saw recurring patterns. These new templates match the patterns we've
seen so far on the OSCAL-related projects under EasyDynamics and these
are hopefully generic enough to support most projects' needs.
