### PR TITLE
Fix validation errors in GitHub issue forms

### DIFF
--- a/ISSUE_TEMPLATE/bug.yml
+++ b/ISSUE_TEMPLATE/bug.yml
@@ -10,8 +10,8 @@ body:
       label: Description
       description: >-
         Please provide a general description of the bug you're experiencing
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: input
     id: environment
@@ -20,8 +20,8 @@ body:
       description: >-
         If the issue is ocurring in a particular environment, please provide its
         name or URL
-      validations:
-        required: false
+    validations:
+      required: false
 
   - type: textarea
     id: reproduction
@@ -32,8 +32,8 @@ body:
 
         If there is a particular code sample that can be provided, please provide either a
         link or a relevant snippet of the code.
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: textarea
     id: expected-behavior
@@ -41,8 +41,8 @@ body:
       label: Expected behavior
       description: >-
         What did you expect to happen when you encountered the bug?
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: textarea
     id: actual-behavior
@@ -51,8 +51,8 @@ body:
       description: >-
         What unexpected behavior actually occurred? Please include specific error messages,
         if relevant.
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: textarea
     id: notes
@@ -60,5 +60,5 @@ body:
       label: Additional Notes
       description: >-
         Any additional information that you feel may be relevant to this bug report
-      validations:
-        required: false
+    validations:
+      required: false

--- a/ISSUE_TEMPLATE/feature.yml
+++ b/ISSUE_TEMPLATE/feature.yml
@@ -14,8 +14,8 @@ body:
         [user story](https://www.atlassian.com/agile/project-management/user-stories), such as:
 
         > As a user, I want to [feature], so that [use case].
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: textarea
     id: acceptance
@@ -23,8 +23,8 @@ body:
       label: Acceptance Criteria
       description: >-
         The conditions that must be met for this ticket to be accepted
-      validations:
-        required: false
+    validations:
+      required: false
 
   - type: textarea
     id: solution
@@ -32,17 +32,17 @@ body:
       label: Proposed Solution
       description: >-
         If you have an idea for how this feature could be implemented, please provide that
-      validations:
-        required: false
+    validations:
+      required: false
 
   - type: textarea
     id: notes
     attributes:
       label: Additional Notes
       description: >-
-        foo
-      validations:
-        required: false
+        Any additional information that you feel may be relevant to this feature request
+    validations:
+      required: false
 
   - type: checkboxes
     id: implementation


### PR DESCRIPTION
For some reason, these did not start appearing on our repositories after
they were added. After playing around with them a bit on a personal
repository, it looks like there are some validation errors. This tries
to resolve those.

This still *may* not work. Issue forms are in beta for public repos and
I wonder if they're not supported from the `.github` repository yet. If
that's the case, I will convert these to issue templates which we may be
able to use.
